### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,12 @@ jobs:
     - name: Test
       run: go test -v ./...
 
+    - name: Store Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: flagon
+        path: flagon
+
     - name: Publish Release
       if: github.ref_name == 'main'
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,10 @@ jobs:
       run: go generate ./...
 
     - name: Build
+      env:
+        GOOS: linux
+        GOARCH: amd64
+        CGO_ENABLED: "0"
       run: go build -ldflags="-X flagon/version.GitCommit=${{ github.sha }} -X flagon/version.Prerelease="""
 
     - name: Test

--- a/.github/workflows/create-release.sh
+++ b/.github/workflows/create-release.sh
@@ -31,5 +31,5 @@ curl -X POST \
   --url "https://${upload_url}?name=flagon" \
   --header "Authorization: ${AUTH}" \
   --header "Accept: application/vnd.github+json" \
-  --header "Content-Type: application/octet-stream" \
-  -d @flagon
+  --header "Content-Type: $(file -b --mime-type flagon)" \
+  --data-binary @flagon

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.0.3] - 2022-11-15
+
+### Fixed
+
+- Fix the build's upload binary call, which was truncating the binary file
+
+### Changed
+
+- Statically link the binary in github actions
+
 ## [0.0.2] - 2022-11-14
 
 ### Fixed


### PR DESCRIPTION

Statically links the `flagon` binary, stores it as an artifact for each build so that it can be tested without drafting a release, and fixes the release binary upload, which was using `-d` rather than `--data-binary`, which caused the file to be truncated at 5.7mb